### PR TITLE
Changed tag prefix from 'release/' to 'version/'

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -2,7 +2,7 @@ name: publish
 on:
   push:
     tags:
-      - 'release/*'
+      - 'version/*'
 
 
 env: 


### PR DESCRIPTION
Changed tag prefix in action from 'release/' to 'version/' so there's no branch conflict when creating the tags.