### PR TITLE
Add AsepriteFileReader.Read() method with a Stream parameter

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,4 +15,6 @@ Thumbs.db
 # Ignore packages dir for local package installs used by the example projects
 [Pp]ackages/
 
+# Visual Studio
+.vs/
 

--- a/source/MonoGame.Aseprite/Content/Readers/AsepriteFileReader.cs
+++ b/source/MonoGame.Aseprite/Content/Readers/AsepriteFileReader.cs
@@ -22,6 +22,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 ---------------------------------------------------------------------------- */
 
+using System.Diagnostics.CodeAnalysis;
 using System.Text;
 using Microsoft.Xna.Framework;
 using MonoGame.Aseprite.AsepriteTypes;
@@ -71,10 +72,38 @@ public static class AsepriteFileReader
             throw new FileNotFoundException($"Unable to locate a file at the path '{path}'");
         }
 
-        using Stream stream = TitleContainer.OpenStream(path);
+        using Stream stream = File.OpenRead(path);
         using BinaryReader reader = new(stream);
 
         string name = Path.GetFileNameWithoutExtension(path);
+        return Read(name, reader);
+    }
+
+    /// <summary>
+    ///     Reads the <see cref="AsepriteFile"/> using the provided <see cref="Stream"/>.
+    ///     <br />
+    ///     Use this method with <see cref="TitleContainer.OpenStream(string)"/> to load raw .aseprite files on Android 
+    ///     or other platforms.
+    /// </summary>
+    /// <param name="name">
+    ///     The name of the Aseprite file.
+    /// </param>
+    /// <param name="fileStream">
+    ///     A file stream, preferably instanciated from calling <see cref="TitleContainer.OpenStream(string)"/>.
+    /// </param>
+    /// <returns>
+    ///     The <see cref="AsepriteFile"/> created by this method.
+    /// </returns>
+    /// <exception cref="FileNotFoundException">
+    ///     Thrown if no file is located at the specified path.
+    /// </exception>
+    /// <exception cref="InvalidOperationException">
+    ///     Thrown if an error occurs during the reading of the aseprite file.  The exception message will contain the
+    ///     cause of the exception.
+    /// </exception>
+    public static AsepriteFile ReadStream(string name, [NotNull] Stream fileStream)
+    {
+        using BinaryReader reader = new(fileStream);
         return Read(name, reader);
     }
 

--- a/source/MonoGame.Aseprite/Content/Readers/AsepriteFileReader.cs
+++ b/source/MonoGame.Aseprite/Content/Readers/AsepriteFileReader.cs
@@ -71,7 +71,7 @@ public static class AsepriteFileReader
             throw new FileNotFoundException($"Unable to locate a file at the path '{path}'");
         }
 
-        using Stream stream = File.OpenRead(path);
+        using Stream stream = TitleContainer.OpenStream(path);
         using BinaryReader reader = new(stream);
 
         string name = Path.GetFileNameWithoutExtension(path);

--- a/tests/MonoGame.Aseprite.Tests/IOTests/AsepriteFileReaderTests.cs
+++ b/tests/MonoGame.Aseprite.Tests/IOTests/AsepriteFileReaderTests.cs
@@ -37,12 +37,29 @@ public sealed class AsepriteFileReaderTests
     private readonly Color _blue = new Color(0, 0, 255, 255);
     private readonly Color _transparent = new Color(0, 0, 0, 0);
 
+
+
+    [Fact]
+    public void ReadsStream_Version_1_3_0_Expected_Values()
+    {
+        string path = FileUtils.GetLocalPath("aseprite-1.3.0-file-reader-test.aseprite");
+        Stream fileStream = File.OpenRead(path);
+        AsepriteFile aseFile = AsepriteFileReader.ReadStream(Path.GetFileNameWithoutExtension(path), fileStream);
+
+        Reads_Version_1_3_0_Assertions(aseFile);
+    }
+
     [Fact]
     public void Reads_Version_1_3_0_Expected_Values()
     {
         string path = FileUtils.GetLocalPath("aseprite-1.3.0-file-reader-test.aseprite");
         AsepriteFile aseFile = AsepriteFileReader.ReadFile(path);
 
+        Reads_Version_1_3_0_Assertions(aseFile);
+    }
+
+    private void Reads_Version_1_3_0_Assertions(AsepriteFile aseFile)
+    {
         //  ************************************************************
         //  File properties
         //  ************************************************************


### PR DESCRIPTION
As discussed on discord, AsepriteReader now allows platform-specific reading method for content files.