### PR TITLE
Hotfix/textureatlas fromraw

### DIFF
--- a/.github/release-notes.txt
+++ b/.github/release-notes.txt
@@ -1,3 +1,7 @@
-## Bug Fixes
+## 4.0.2 Hotfix
 - Fixed XML docs not included in NuGet leading to no intellesense. (Closes #44)
 - Fixed RawTexture.Height property being internal by making it public (Closes #45)
+
+## 4.0.3 Hotfix
+- Fixed crash in `TextureAtlas.FromRaw` where loop for slices used incorrect iterator. (Closes #52)
+

--- a/.nuget/README.md
+++ b/.nuget/README.md
@@ -3,7 +3,7 @@
 A Cross Platform C# Library That Adds Support For Aseprite Files in MonoGame Projects.
 
 [![build-and-test](https://github.com/AristurtleDev/monogame-aseprite/actions/workflows/buildandtest.yml/badge.svg)](https://github.com/AristurtleDev/monogame-aseprite/actions/workflows/buildandtest.yml)
-[![Nuget 4.0.0](https://img.shields.io/nuget/v/MonoGame.Aseprite?color=blue&style=flat-square)](https://www.nuget.org/packages/MonoGame.Aseprite/4.0.0)
+[![Nuget 4.0.3](https://img.shields.io/nuget/v/MonoGame.Aseprite?color=blue&style=flat-square)](https://www.nuget.org/packages/MonoGame.Aseprite/4.0.3)
 [![License: MIT](https://img.shields.io/badge/📃%20license-MIT-blue?style=flat)](LICENSE)
 [![Twitter](https://img.shields.io/badge/%20-Share%20On%20Twitter-555?style=flat&logo=twitter)](https://twitter.com/intent/tweet?text=MonoGame.Aseprite%20by%20%40aristurtledev%0A%0AA%20cross-platform%20C%23%20library%20that%20adds%20support%20for%20Aseprite%20files%20in%20MonoGame%20projects.%20https%3A%2F%2Fgithub.com%2FAristurtleDev%2Fmonogame-aseprite%0A%0A%23monogame%20%23aseprite%20%23dotnet%20%23csharp%20%23oss%0A)
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 A Cross Platform C# Library That Adds Support For Aseprite Files in MonoGame Projects.
 
 [![build-and-test](https://github.com/AristurtleDev/monogame-aseprite/actions/workflows/buildandtest.yml/badge.svg)](https://github.com/AristurtleDev/monogame-aseprite/actions/workflows/buildandtest.yml)
-[![Nuget 4.0.2](https://img.shields.io/nuget/v/MonoGame.Aseprite?color=blue&style=flat-square)](https://www.nuget.org/packages/MonoGame.Aseprite/4.0.0)
+[![Nuget 4.0.3](https://img.shields.io/nuget/v/MonoGame.Aseprite?color=blue&style=flat-square)](https://www.nuget.org/packages/MonoGame.Aseprite/4.0.3)
 [![License: MIT](https://img.shields.io/badge/📃%20license-MIT-blue?style=flat)](LICENSE)
 [![Twitter](https://img.shields.io/badge/%20-Share%20On%20Twitter-555?style=flat&logo=twitter)](https://twitter.com/intent/tweet?text=MonoGame.Aseprite%20by%20%40aristurtledev%0A%0AA%20cross-platform%20C%23%20library%20that%20adds%20support%20for%20Aseprite%20files%20in%20MonoGame%20projects.%20https%3A%2F%2Fgithub.com%2FAristurtleDev%2Fmonogame-aseprite%0A%0A%23monogame%20%23aseprite%20%23dotnet%20%23csharp%20%23oss%0A)
 

--- a/source/MonoGame.Aseprite.Content.Pipeline/MonoGame.Aseprite.Content.Pipeline.csproj
+++ b/source/MonoGame.Aseprite.Content.Pipeline/MonoGame.Aseprite.Content.Pipeline.csproj
@@ -4,7 +4,7 @@
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
         <GenerateDocumentationFile>False</GenerateDocumentationFile>
-        <Version>4.0.2</Version>
+        <Version>4.0.3</Version>
     </PropertyGroup>
 
     <PropertyGroup>
@@ -21,9 +21,9 @@
     <!-- dotnet pack Nuget Config stuff -->
     <PropertyGroup>
         <PackageId>MonoGame.Aseprite.Content.Pipeline</PackageId>
-        <Version>4.0.0</Version>
-        <AssemblyVersion>4.0.0</AssemblyVersion>
-        <FileVersion>4.0.0</FileVersion>
+        <Version>4.0.3</Version>
+        <AssemblyVersion>4.0.3</AssemblyVersion>
+        <FileVersion>4.0.3</FileVersion>
         <Authors>Christopher Whitley</Authors>
         <Company>Aristurtle</Company>
         <PackageLicenseExpression>MIT</PackageLicenseExpression>
@@ -37,7 +37,7 @@
         <PackageTags>
             MonoGame;Aseprite;import;processes;read;write;sprite;animation;tileset;tilemap;spritesheet;pipeline;mgcb</PackageTags>
         <PackageReleaseNotes>
-            Version 4.0.2
+            Version 4.0.3
             The following bug fixes were implemented:
                 - Fixed XML docs not included in NuGet leading to no intellesense. (Closes #44)
                 - Fixed RawTexture.Height property being internal by making it public (Closes #45)

--- a/source/MonoGame.Aseprite/MonoGame.Aseprite.csproj
+++ b/source/MonoGame.Aseprite/MonoGame.Aseprite.csproj
@@ -4,7 +4,7 @@
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
         <GenerateDocumentationFile>False</GenerateDocumentationFile>
-        <Version>4.0.2</Version>
+        <Version>4.0.3</Version>
     </PropertyGroup>
 
     <PropertyGroup>
@@ -29,7 +29,7 @@
         </PackageTags>
         <PackageReadmeFile>README.md</PackageReadmeFile>
         <PackageReleaseNotes>
-            Version 4.0.2
+            Version 4.0.3
             The following bug fixes were implemented:
                 - Fixed XML docs not included in NuGet leading to no intellesense. (Closes #44)
                 - Fixed RawTexture.Height property being internal by making it public (Closes #45)

--- a/source/MonoGame.Aseprite/Sprites/TextureAtlas.cs
+++ b/source/MonoGame.Aseprite/Sprites/TextureAtlas.cs
@@ -576,7 +576,7 @@ public class TextureAtlas : IEnumerable<TextureRegion>
 
             for (int s = 0; s < rawTextureRegion.Slices.Length; s++)
             {
-                RawSlice slice = rawTextureRegion.Slices[i];
+                RawSlice slice = rawTextureRegion.Slices[s];
 
                 if (slice is RawNinePatchSlice ninePatch)
                 {


### PR DESCRIPTION
This is to resolve the the crash issue #52  in `TextureAtlas.FromRaw` where the incorrect iterator variable is used when looping through slices.