### PR TITLE
Hotfix/animation update

### DIFF
--- a/.github/release-notes.txt
+++ b/.github/release-notes.txt
@@ -5,3 +5,8 @@
 ## 4.0.3 Hotfix
 - Fixed crash in `TextureAtlas.FromRaw` where loop for slices used incorrect iterator. (Closes #52)
 
+## 4.0.4 Hotfix
+- `AnimatedSprite.Update(float)` changed to `AnimatedSprite.Update(double)` (Closes #51)
+- `AnimatedTilemap.Update(float)` changed to `AnimatedTilemap.Update(double)` (Closes #51)
+- `AnimatedSprite.Update(double)` and `AnimatedTilemap.Update(double)` now expect the value being passed to be a representation of elapsed seconds and not elapsed milliseconds.  This is in-line with the common use case of delta time being representative of seconds elapsed and not milliseconds elapsed. (Closes #61)
+

--- a/.nuget/README.md
+++ b/.nuget/README.md
@@ -3,7 +3,7 @@
 A Cross Platform C# Library That Adds Support For Aseprite Files in MonoGame Projects.
 
 [![build-and-test](https://github.com/AristurtleDev/monogame-aseprite/actions/workflows/buildandtest.yml/badge.svg)](https://github.com/AristurtleDev/monogame-aseprite/actions/workflows/buildandtest.yml)
-[![Nuget 4.0.3](https://img.shields.io/nuget/v/MonoGame.Aseprite?color=blue&style=flat-square)](https://www.nuget.org/packages/MonoGame.Aseprite/4.0.3)
+[![Nuget 4.0.4](https://img.shields.io/nuget/v/MonoGame.Aseprite?color=blue&style=flat-square)](https://www.nuget.org/packages/MonoGame.Aseprite/4.0.4)
 [![License: MIT](https://img.shields.io/badge/📃%20license-MIT-blue?style=flat)](LICENSE)
 [![Twitter](https://img.shields.io/badge/%20-Share%20On%20Twitter-555?style=flat&logo=twitter)](https://twitter.com/intent/tweet?text=MonoGame.Aseprite%20by%20%40aristurtledev%0A%0AA%20cross-platform%20C%23%20library%20that%20adds%20support%20for%20Aseprite%20files%20in%20MonoGame%20projects.%20https%3A%2F%2Fgithub.com%2FAristurtleDev%2Fmonogame-aseprite%0A%0A%23monogame%20%23aseprite%20%23dotnet%20%23csharp%20%23oss%0A)
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 A Cross Platform C# Library That Adds Support For Aseprite Files in MonoGame Projects.
 
 [![build-and-test](https://github.com/AristurtleDev/monogame-aseprite/actions/workflows/buildandtest.yml/badge.svg)](https://github.com/AristurtleDev/monogame-aseprite/actions/workflows/buildandtest.yml)
-[![Nuget 4.0.3](https://img.shields.io/nuget/v/MonoGame.Aseprite?color=blue&style=flat-square)](https://www.nuget.org/packages/MonoGame.Aseprite/4.0.3)
+[![Nuget 4.0.4](https://img.shields.io/nuget/v/MonoGame.Aseprite?color=blue&style=flat-square)](https://www.nuget.org/packages/MonoGame.Aseprite/4.0.4)
 [![License: MIT](https://img.shields.io/badge/📃%20license-MIT-blue?style=flat)](LICENSE)
 [![Twitter](https://img.shields.io/badge/%20-Share%20On%20Twitter-555?style=flat&logo=twitter)](https://twitter.com/intent/tweet?text=MonoGame.Aseprite%20by%20%40aristurtledev%0A%0AA%20cross-platform%20C%23%20library%20that%20adds%20support%20for%20Aseprite%20files%20in%20MonoGame%20projects.%20https%3A%2F%2Fgithub.com%2FAristurtleDev%2Fmonogame-aseprite%0A%0A%23monogame%20%23aseprite%20%23dotnet%20%23csharp%20%23oss%0A)
 

--- a/source/MonoGame.Aseprite.Content.Pipeline/MonoGame.Aseprite.Content.Pipeline.csproj
+++ b/source/MonoGame.Aseprite.Content.Pipeline/MonoGame.Aseprite.Content.Pipeline.csproj
@@ -4,7 +4,7 @@
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
         <GenerateDocumentationFile>False</GenerateDocumentationFile>
-        <Version>4.0.3</Version>
+        <Version>4.0.4</Version>
     </PropertyGroup>
 
     <PropertyGroup>
@@ -21,9 +21,9 @@
     <!-- dotnet pack Nuget Config stuff -->
     <PropertyGroup>
         <PackageId>MonoGame.Aseprite.Content.Pipeline</PackageId>
-        <Version>4.0.3</Version>
-        <AssemblyVersion>4.0.3</AssemblyVersion>
-        <FileVersion>4.0.3</FileVersion>
+        <Version>4.0.4</Version>
+        <AssemblyVersion>4.0.4</AssemblyVersion>
+        <FileVersion>4.0.4</FileVersion>
         <Authors>Christopher Whitley</Authors>
         <Company>Aristurtle</Company>
         <PackageLicenseExpression>MIT</PackageLicenseExpression>
@@ -37,7 +37,7 @@
         <PackageTags>
             MonoGame;Aseprite;import;processes;read;write;sprite;animation;tileset;tilemap;spritesheet;pipeline;mgcb</PackageTags>
         <PackageReleaseNotes>
-            Version 4.0.3
+            Version 4.0.4
             The following bug fixes were implemented:
                 - Fixed crash in `TextureAtlas.FromRaw` where loop for slices used incorrect iterator. (Closes #52)
         </PackageReleaseNotes>

--- a/source/MonoGame.Aseprite/MonoGame.Aseprite.csproj
+++ b/source/MonoGame.Aseprite/MonoGame.Aseprite.csproj
@@ -4,7 +4,7 @@
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
         <GenerateDocumentationFile>False</GenerateDocumentationFile>
-        <Version>4.0.3</Version>
+        <Version>4.0.4</Version>
     </PropertyGroup>
 
     <PropertyGroup>
@@ -29,7 +29,7 @@
         </PackageTags>
         <PackageReadmeFile>README.md</PackageReadmeFile>
         <PackageReleaseNotes>
-            Version 4.0.3
+            Version 4.0.4
             The following bug fixes were implemented:
                 - Fixed crash in `TextureAtlas.FromRaw` where loop for slices used incorrect iterator. (Closes #52)
         </PackageReleaseNotes>

--- a/source/MonoGame.Aseprite/Sprites/AnimatedSprite.cs
+++ b/source/MonoGame.Aseprite/Sprites/AnimatedSprite.cs
@@ -109,13 +109,13 @@ public sealed class AnimatedSprite : Sprite
     /// <remarks>
     ///     This should only be called once per update cycle.
     /// </remarks>
-    /// <param name="deltaTimeInMilliseconds">
-    ///     The amount of time, in milliseconds, that have elapsed since the last update cycle in the game.
+    /// <param name="deltaTimeInSeconds">
+    ///     The amount of time, in seconds, that have elapsed since the last update cycle in the game.
     /// </param>
-    public void Update(float deltaTimeInMilliseconds)
+    public void Update(double deltaTimeInSeconds)
     {
         GameTime fakeGameTime = new();
-        fakeGameTime.ElapsedGameTime = TimeSpan.FromMilliseconds(deltaTimeInMilliseconds);
+        fakeGameTime.ElapsedGameTime = TimeSpan.FromSeconds(deltaTimeInSeconds);
         Update(fakeGameTime);
     }
 

--- a/source/MonoGame.Aseprite/Tilemaps/AnimatedTilemap.cs
+++ b/source/MonoGame.Aseprite/Tilemaps/AnimatedTilemap.cs
@@ -179,13 +179,13 @@ public sealed class AnimatedTilemap : IEnumerable<AnimatedTilemapFrame>
     /// <remarks>
     ///     This should only be called once per game update cycle.
     /// </remarks>
-    /// <param name="deltaTimeInMilliseconds">
-    ///     The amount of time, in milliseconds, that have elapsed since the last update cycle in the game.
+    /// <param name="deltaTimeInSeconds">
+    ///     The amount of time, in seconds, that have elapsed since the last update cycle in the game.
     /// </param>
-    public void Update(float deltaTimeInMilliseconds)
+    public void Update(double deltaTimeInSeconds)
     {
         GameTime fakeGameTime = new();
-        fakeGameTime.ElapsedGameTime = TimeSpan.FromMilliseconds(deltaTimeInMilliseconds);
+        fakeGameTime.ElapsedGameTime = TimeSpan.FromSeconds(deltaTimeInSeconds);
         Update(fakeGameTime);
     }
 


### PR DESCRIPTION
This hotfix resolves the following issues
* #51 
    * This should have been `double` to begin with since testing shows animation issues due to `float` precision loss
* #61 
    * The should have be `deltaTimeInSeconds` to align with the more common use-case of using elapsed seconds as the delta time and not elapsed milliseconds.