### PR TITLE
Set `Origin` property in constructor

### DIFF
--- a/.github/release-notes.txt
+++ b/.github/release-notes.txt
@@ -10,3 +10,5 @@
 - `AnimatedTilemap.Update(float)` changed to `AnimatedTilemap.Update(double)` (Closes #51)
 - `AnimatedSprite.Update(double)` and `AnimatedTilemap.Update(double)` now expect the value being passed to be a representation of elapsed seconds and not elapsed milliseconds.  This is in-line with the common use case of delta time being representative of seconds elapsed and not milliseconds elapsed. (Closes #61)
 
+## 4.0.5 Hotfix
+- `Slice.Origin` value is not set property in constructor. (Closes #64)

--- a/.nuget/README.md
+++ b/.nuget/README.md
@@ -3,7 +3,7 @@
 A Cross Platform C# Library That Adds Support For Aseprite Files in MonoGame Projects.
 
 [![build-and-test](https://github.com/AristurtleDev/monogame-aseprite/actions/workflows/buildandtest.yml/badge.svg)](https://github.com/AristurtleDev/monogame-aseprite/actions/workflows/buildandtest.yml)
-[![Nuget 4.0.4](https://img.shields.io/nuget/v/MonoGame.Aseprite?color=blue&style=flat-square)](https://www.nuget.org/packages/MonoGame.Aseprite/4.0.4)
+[![Nuget 4.0.5](https://img.shields.io/nuget/v/MonoGame.Aseprite?color=blue&style=flat-square)](https://www.nuget.org/packages/MonoGame.Aseprite/4.0.5)
 [![License: MIT](https://img.shields.io/badge/📃%20license-MIT-blue?style=flat)](LICENSE)
 [![Twitter](https://img.shields.io/badge/%20-Share%20On%20Twitter-555?style=flat&logo=twitter)](https://twitter.com/intent/tweet?text=MonoGame.Aseprite%20by%20%40aristurtledev%0A%0AA%20cross-platform%20C%23%20library%20that%20adds%20support%20for%20Aseprite%20files%20in%20MonoGame%20projects.%20https%3A%2F%2Fgithub.com%2FAristurtleDev%2Fmonogame-aseprite%0A%0A%23monogame%20%23aseprite%20%23dotnet%20%23csharp%20%23oss%0A)
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 A Cross Platform C# Library That Adds Support For Aseprite Files in MonoGame Projects.
 
 [![build-and-test](https://github.com/AristurtleDev/monogame-aseprite/actions/workflows/buildandtest.yml/badge.svg)](https://github.com/AristurtleDev/monogame-aseprite/actions/workflows/buildandtest.yml)
-[![Nuget 4.0.4](https://img.shields.io/nuget/v/MonoGame.Aseprite?color=blue&style=flat-square)](https://www.nuget.org/packages/MonoGame.Aseprite/4.0.4)
+[![Nuget 4.0.5](https://img.shields.io/nuget/v/MonoGame.Aseprite?color=blue&style=flat-square)](https://www.nuget.org/packages/MonoGame.Aseprite/4.0.5)
 [![License: MIT](https://img.shields.io/badge/📃%20license-MIT-blue?style=flat)](LICENSE)
 [![Twitter](https://img.shields.io/badge/%20-Share%20On%20Twitter-555?style=flat&logo=twitter)](https://twitter.com/intent/tweet?text=MonoGame.Aseprite%20by%20%40aristurtledev%0A%0AA%20cross-platform%20C%23%20library%20that%20adds%20support%20for%20Aseprite%20files%20in%20MonoGame%20projects.%20https%3A%2F%2Fgithub.com%2FAristurtleDev%2Fmonogame-aseprite%0A%0A%23monogame%20%23aseprite%20%23dotnet%20%23csharp%20%23oss%0A)
 

--- a/source/MonoGame.Aseprite.Content.Pipeline/MonoGame.Aseprite.Content.Pipeline.csproj
+++ b/source/MonoGame.Aseprite.Content.Pipeline/MonoGame.Aseprite.Content.Pipeline.csproj
@@ -37,11 +37,9 @@
         <PackageTags>
             MonoGame;Aseprite;import;processes;read;write;sprite;animation;tileset;tilemap;spritesheet;pipeline;mgcb</PackageTags>
         <PackageReleaseNotes>
-            Version 4.0.4
+            Version 4.0.5
             The following bug fixes were implemented:
-                - `AnimatedSprite.Update(float)` changed to `AnimatedSprite.Update(double)` (Closes #51)
-                - `AnimatedTilemap.Update(float)` changed to `AnimatedTilemap.Update(double)` (Closes #51)
-                - `AnimatedSprite.Update(double)` and `AnimatedTilemap.Update(double)` now expect the value being passed to be a representation of elapsed seconds and not elapsed milliseconds.  This is in-line with the common use case of delta time being representative of seconds elapsed and not milliseconds elapsed. (Closes #61)
+                - `Slice.Origin` value is not set property in constructor. (Closes #64)
         </PackageReleaseNotes>
         <Description>
             MonoGame.Aseprite.Content.Pipeline is a cross-platform C# library that adds an extension to the MonoGame

--- a/source/MonoGame.Aseprite.Content.Pipeline/MonoGame.Aseprite.Content.Pipeline.csproj
+++ b/source/MonoGame.Aseprite.Content.Pipeline/MonoGame.Aseprite.Content.Pipeline.csproj
@@ -4,7 +4,7 @@
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
         <GenerateDocumentationFile>False</GenerateDocumentationFile>
-        <Version>4.0.4</Version>
+        <Version>4.0.5</Version>
     </PropertyGroup>
 
     <PropertyGroup>
@@ -21,9 +21,9 @@
     <!-- dotnet pack Nuget Config stuff -->
     <PropertyGroup>
         <PackageId>MonoGame.Aseprite.Content.Pipeline</PackageId>
-        <Version>4.0.4</Version>
-        <AssemblyVersion>4.0.4</AssemblyVersion>
-        <FileVersion>4.0.4</FileVersion>
+        <Version>4.0.5</Version>
+        <AssemblyVersion>4.0.5</AssemblyVersion>
+        <FileVersion>4.0.5</FileVersion>
         <Authors>Christopher Whitley</Authors>
         <Company>Aristurtle</Company>
         <PackageLicenseExpression>MIT</PackageLicenseExpression>

--- a/source/MonoGame.Aseprite/MonoGame.Aseprite.csproj
+++ b/source/MonoGame.Aseprite/MonoGame.Aseprite.csproj
@@ -29,11 +29,9 @@
         </PackageTags>
         <PackageReadmeFile>README.md</PackageReadmeFile>
         <PackageReleaseNotes>
-            Version 4.0.4
+            Version 4.0.5
             The following bug fixes were implemented:
-                - `AnimatedSprite.Update(float)` changed to `AnimatedSprite.Update(double)` (Closes #51)
-                - `AnimatedTilemap.Update(float)` changed to `AnimatedTilemap.Update(double)` (Closes #51)
-                - `AnimatedSprite.Update(double)` and `AnimatedTilemap.Update(double)` now expect the value being passed to be a representation of elapsed seconds and not elapsed milliseconds.  This is in-line with the common use case of delta time being representative of seconds elapsed and not milliseconds elapsed. (Closes #61)
+                - `Slice.Origin` value is not set property in constructor. (Closes #64)
         </PackageReleaseNotes>
         <Description>
             MonoGame.Aseprite is a cross-platofrm C# library that adds support to MonoGame projects for

--- a/source/MonoGame.Aseprite/MonoGame.Aseprite.csproj
+++ b/source/MonoGame.Aseprite/MonoGame.Aseprite.csproj
@@ -4,7 +4,7 @@
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
         <GenerateDocumentationFile>False</GenerateDocumentationFile>
-        <Version>4.0.4</Version>
+        <Version>4.0.5</Version>
     </PropertyGroup>
 
     <PropertyGroup>

--- a/source/MonoGame.Aseprite/Slice.cs
+++ b/source/MonoGame.Aseprite/Slice.cs
@@ -55,5 +55,5 @@ public class Slice
     public Color Color { get; }
 
     internal Slice(string name, Rectangle bounds, Vector2 origin, Color color) =>
-        (Name, Bounds, Color) = (name, bounds, color);
+        (Name, Bounds, Origin, Color) = (name, bounds, origin, color);
 }


### PR DESCRIPTION
This is to fix the bug where the `Slice.Origin` property is not set in the constructor.
Reference #64 