### PR TITLE
Made AsepriteCel properties accessible

### DIFF
--- a/source/MonoGame.Aseprite.Shared/AsepriteTypes/AsepriteCel.cs
+++ b/source/MonoGame.Aseprite.Shared/AsepriteTypes/AsepriteCel.cs
@@ -40,17 +40,17 @@ public abstract class AsepriteCel
     ///     Gets the x- and y-coordinate location of this <see cref="AsepriteCel"/> relative to the bounds of the 
     ///     <see cref="AsepriteFrame"/> it is in.
     /// </summary>
-    internal Point Position { get; }
+    public Point Position { get; }
 
     /// <summary>
     ///     Gets the opacity level of this <see cref="AsepriteCel"/>.
     /// </summary>
-    internal int Opacity { get; }
+    public int Opacity { get; }
 
     /// <summary>
     ///     Gets the custom <see cref="AsepriteUserData"/> that was set for this <see cref="AsepriteCel"/> in aseprite.
     /// </summary>
-    internal AsepriteUserData UserData { get; } = new();
+    public AsepriteUserData UserData { get; } = new();
 
     internal AsepriteCel(AsepriteLayer layer, Point position, int opacity) =>
         (Layer, Position, Opacity) = (layer, position, opacity);


### PR DESCRIPTION
## Prerequisites
- [x] I have verified that there are no existing pull requests that would overlap with this pull request.
- [x] I have verified that I am following the guidelines as outlined in this project's contribution policy
- [x] I Have verified that this pull request adheres to this project's code of conduct.
- [x] I have written a descriptive title for this pull request.
- [x] I have provided appropriate test coverage were applicable.

## Description
This merges changes made in the fork by @SephDB to make the `AsepriteCel` properties accessible. They were mistakenly marked as `internal` and should have always been `public`

I'll open this as draft and if @SephDB is good with it, I'll merge the changes in to be part of the next update release unless they would like to formally open the PR themself.

## Related Issue Ticket Numbers
No related issue.
<!-- Provided a bulleted list of related issues in this project this pull request is addressing, if any -->
