### PR TITLE
Added Update to AnimatedSprite & AnimatedTilemap with TimeSpan support

### DIFF
--- a/source/MonoGame.Aseprite/Sprites/AnimatedSprite.cs
+++ b/source/MonoGame.Aseprite/Sprites/AnimatedSprite.cs
@@ -167,9 +167,7 @@ public sealed class AnimatedSprite : Sprite
     /// </param>
     public void Update(double deltaTimeInSeconds)
     {
-        GameTime fakeGameTime = new();
-        fakeGameTime.ElapsedGameTime = TimeSpan.FromSeconds(deltaTimeInSeconds);
-        Update(fakeGameTime);
+        Update(TimeSpan.FromSeconds(deltaTimeInSeconds));
     }
 
     /// <summary>
@@ -182,6 +180,20 @@ public sealed class AnimatedSprite : Sprite
     ///     A snapshot of the game timing values for the current update cycle.
     /// </param>
     public void Update(GameTime gameTime)
+    {
+        Update(gameTime.ElapsedGameTime);
+    }
+
+    /// <summary>
+    ///     Updates this <see cref="AnimatedSprite"/>.
+    /// </summary>
+    /// <remarks>
+    ///     This should only be called once per update cycle.
+    /// </remarks>
+    /// <param name="elapsedTime">
+    ///     The amount of time, that have elapsed since the last update cycle in the game.
+    /// </param>
+    public void Update(in TimeSpan elapsedTime)
     {
         if (!IsAnimating || IsPaused)
         {
@@ -199,7 +211,7 @@ public sealed class AnimatedSprite : Sprite
             OnFrameBegin?.Invoke(this);
         }
 
-        CurrentFrameTimeRemaining -= gameTime.ElapsedGameTime * Speed;
+        CurrentFrameTimeRemaining -= elapsedTime * Speed;
 
         if (CurrentFrameTimeRemaining <= TimeSpan.Zero)
         {

--- a/source/MonoGame.Aseprite/Tilemaps/AnimatedTilemap.cs
+++ b/source/MonoGame.Aseprite/Tilemaps/AnimatedTilemap.cs
@@ -184,9 +184,7 @@ public sealed class AnimatedTilemap : IEnumerable<AnimatedTilemapFrame>
     /// </param>
     public void Update(double deltaTimeInSeconds)
     {
-        GameTime fakeGameTime = new();
-        fakeGameTime.ElapsedGameTime = TimeSpan.FromSeconds(deltaTimeInSeconds);
-        Update(fakeGameTime);
+        Update(TimeSpan.FromSeconds(deltaTimeInSeconds));
     }
 
     /// <summary>
@@ -199,6 +197,20 @@ public sealed class AnimatedTilemap : IEnumerable<AnimatedTilemapFrame>
     ///     A snapshot of the game timing values for the current update cycle.
     /// </param>
     public void Update(GameTime gameTime)
+    {
+        Update(gameTime.ElapsedGameTime);
+    }
+
+    /// <summary>
+    ///     Updates this <see cref="AnimatedTilemap"/>.
+    /// </summary>
+    /// <remarks>
+    ///     This should only be called once per game update cycle.
+    /// </remarks>
+    /// <param name="elapsedTime">
+    ///     The amount of time, that have elapsed since the last update cycle in the game.
+    /// </param>
+    public void Update(in TimeSpan elapsedTime)
     {
         if (!IsAnimating || IsPaused)
         {
@@ -216,7 +228,7 @@ public sealed class AnimatedTilemap : IEnumerable<AnimatedTilemapFrame>
             OnFrameBegin?.Invoke(this);
         }
 
-        CurrentFrameTimeRemaining -= gameTime.ElapsedGameTime;
+        CurrentFrameTimeRemaining -= elapsedTime;
 
         if (CurrentFrameTimeRemaining <= TimeSpan.Zero)
         {


### PR DESCRIPTION
## Prerequisites
- [x] I have verified that there are no existing pull requests that would overlap with this pull request.
- [x] I have verified that I am following the guidelines as outlined in this project's contribution policy
- [x] I Have verified that this pull request adheres to this project's code of conduct.
- [x] I have written a descriptive title for this pull request.
- [x] I have provided appropriate test coverage were applicable.

## Description
Added Update(TimeSpan) methods to the AnimatedSprite & AnimatedTilemap classes, this removed the requirement to create a fake GameTime every Update when calling the Update(double deltaTime) overload.

## Related Issue Ticket Numbers
n/a