### PR TITLE
Add compatibility with FNA

### DIFF
--- a/source/MonoGame.Aseprite/MonoGame.Aseprite.FNA.csproj
+++ b/source/MonoGame.Aseprite/MonoGame.Aseprite.FNA.csproj
@@ -1,0 +1,31 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+    <!-- Project level compilation properties -->
+    <PropertyGroup>
+        <TargetFrameworks>net8.0</TargetFrameworks>
+        <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    </PropertyGroup>
+
+    <!-- Project level package properties -->
+    <PropertyGroup>
+        <PackageId>MonoGame.Aseprite.FNA</PackageId>
+        <Description>
+            MonoGame.Aseprite is a cross-platform C# library that adds support to MonoGame projects for
+            Aseprite (.asepirte/.ase) files.
+        </Description>
+    </PropertyGroup>
+
+    <!-- Includes for NuGets -->
+    <ItemGroup>
+        <None Include="..\..\.images\\nuget-icon.png" Pack="true" PackagePath="" />
+        <None Include="..\..\README.md" Pack="true" PackagePath="" />
+        <None Include="$(OutDir)Monogame.Aseprite.xml" Pack="true" PackagePath="lib\net6.0" />
+    </ItemGroup>
+
+    <!-- Project References -->
+    <ItemGroup>
+      <ProjectReference Include="..\..\..\AsepriteDotNet\source\AsepriteDotNet\AsepriteDotNet.csproj" />
+      <ProjectReference Include="..\..\..\FNA\FNA.Core.csproj" />
+    </ItemGroup>
+
+</Project>

--- a/source/MonoGame.Aseprite/MonoGame.Aseprite.FNA.csproj
+++ b/source/MonoGame.Aseprite/MonoGame.Aseprite.FNA.csproj
@@ -6,22 +6,6 @@
         <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     </PropertyGroup>
 
-    <!-- Project level package properties -->
-    <PropertyGroup>
-        <PackageId>MonoGame.Aseprite.FNA</PackageId>
-        <Description>
-            MonoGame.Aseprite is a cross-platform C# library that adds support to MonoGame projects for
-            Aseprite (.asepirte/.ase) files.
-        </Description>
-    </PropertyGroup>
-
-    <!-- Includes for NuGets -->
-    <ItemGroup>
-        <None Include="..\..\.images\\nuget-icon.png" Pack="true" PackagePath="" />
-        <None Include="..\..\README.md" Pack="true" PackagePath="" />
-        <None Include="$(OutDir)Monogame.Aseprite.xml" Pack="true" PackagePath="lib\net6.0" />
-    </ItemGroup>
-
     <!-- Project References -->
     <ItemGroup>
       <ProjectReference Include="..\..\..\AsepriteDotNet\source\AsepriteDotNet\AsepriteDotNet.csproj" />

--- a/source/MonoGame.Aseprite/TextureAtlas.cs
+++ b/source/MonoGame.Aseprite/TextureAtlas.cs
@@ -128,7 +128,7 @@ public class TextureAtlas : IEnumerable<TextureRegion>
     /// </exception>
     /// <returns>The <see cref="TextureRegion"/> created by this method.</returns>
     public TextureRegion CreateRegion(string name, Point location, Point size) =>
-        CreateRegion(name, new Rectangle(location, size));
+        CreateRegion(name, new Rectangle(location.X, location.Y, size.X, size.Y));
 
     /// <summary>
     /// Creates a new <see cref="TextureRegion"/> and adds it to this <see cref="TextureAtlas"/>.


### PR DESCRIPTION
## Prerequisites
- [x] I have verified that there are no existing pull requests that would overlap with this pull request.
- [x] I have verified that I am following the guidelines as outlined in this project's contribution policy
- [x] I Have verified that this pull request adheres to this project's code of conduct.
- [x] I have written a descriptive title for this pull request.
- [ ] I have provided appropriate test coverage were applicable.

## Description
I did a single line change on **TextureAtlas.cs**. This is due to the fact that FNA doesn't support as many Rectangle constructors as Monogame does. 

I also consulted very briefly on the FNA discord with some people to check what would be the least surprising way to provide support for FNA. As a result, I am proposing the addition of a new project file that expects the library folder to stay next to the FNA and AsepriteDotNet dependencies.

I also manually tested the examples in the regular monogame solution, to check that nothing was broken with this change.