### PR TITLE
Update/asepritedotnet 1.8.0

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -20,7 +20,7 @@
         <NeutralLanguage>en</NeutralLanguage>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
-        <Version>6.0.3</Version>
+        <Version>6.0.4</Version>
     </PropertyGroup>
 
     <!-- Setup Code Analysis using the .editorconfig file -->

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 A Cross Platform C# Library That Adds Support For Aseprite Files in MonoGame Projects.
 
 [![build-and-test](https://github.com/AristurtleDev/monogame-aseprite/actions/workflows/main.yml/badge.svg)](https://github.com/AristurtleDev/monogame-aseprite/actions/workflows/main.yml)
-[![NuGet 6.0.3](https://img.shields.io/nuget/v/MonoGame.Aseprite?color=blue&style=flat-square)](https://www.nuget.org/packages/MonoGame.Aseprite/6.0.3)
+[![NuGet 6.0.4](https://img.shields.io/nuget/v/MonoGame.Aseprite?color=blue&style=flat-square)](https://www.nuget.org/packages/MonoGame.Aseprite/6.0.4)
 [![License: MIT](https://img.shields.io/badge/📃%20license-MIT-blue?style=flat)](LICENSE)
 [![Twitter](https://img.shields.io/badge/%20-Share%20On%20Twitter-555?style=flat&logo=twitter)](https://twitter.com/intent/tweet?text=MonoGame.Aseprite%20by%20%40aristurtledev%0A%0AA%20cross-platform%20C%23%20library%20that%20adds%20support%20for%20Aseprite%20files%20in%20MonoGame%20projects.%20https%3A%2F%2Fgithub.com%2FAristurtleDev%2Fmonogame-aseprite%0A%0A%23monogame%20%23aseprite%20%23dotnet%20%23csharp%20%23oss%0A)
 
@@ -29,7 +29,7 @@ A Cross Platform C# Library That Adds Support For Aseprite Files in MonoGame Pro
 # Installation
 Install via NuGet
 ```
-dotnet add package MonoGame.Aseprite --version 6.0.3
+dotnet add package MonoGame.Aseprite --version 6.0.4
 ```
 
 # Usage

--- a/source/MonoGame.Aseprite.Content.Pipeline/MonoGame.Aseprite.Content.Pipeline.csproj
+++ b/source/MonoGame.Aseprite.Content.Pipeline/MonoGame.Aseprite.Content.Pipeline.csproj
@@ -27,6 +27,6 @@
         
         <PackageReference Include="MonoGame.Framework.DesktopGL" Version="3.8.1.303" PrivateAssets="All" />
 
-        <PackageReference Include="AsepriteDotNet" Version="1.7.4" />
+        <PackageReference Include="AsepriteDotNet" Version="1.8.0" />
     </ItemGroup>
 </Project>

--- a/source/MonoGame.Aseprite/MonoGame.Aseprite.csproj
+++ b/source/MonoGame.Aseprite/MonoGame.Aseprite.csproj
@@ -25,7 +25,7 @@
 
     <!-- NuGet Package References -->
     <ItemGroup>
-        <PackageReference Include="AsepriteDotNet" Version="1.7.4" />
+        <PackageReference Include="AsepriteDotNet" Version="1.8.0" />
         <PackageReference Include="MonoGame.Framework.DesktopGL" Version="3.8.1.303" PrivateAssets="All" />
     </ItemGroup>
 


### PR DESCRIPTION
## Prerequisites
- [x] I have verified that there are no existing pull requests that would overlap with this pull request.
- [x] I have verified that I am following the guidelines as outlined in this project's contribution policy
- [x] I Have verified that this pull request adheres to this project's code of conduct.
- [x] I have written a descriptive title for this pull request.
- [x] I have provided appropriate test coverage were applicable.

## Description
This bumps the internal dependency on AsepriteDotNet to the just released 1.8.0 version which resolves the issue of slice properties being invalid for both nineslice and pivot.

## Related Issue Ticket Numbers
https://github.com/AristurtleDev/monogame-aseprite/issues/107
https://github.com/AristurtleDev/AsepriteDotNet/issues/26

